### PR TITLE
Ensure we have enough turns of Ode to Booze

### DIFF
--- a/scripts/yaaz/util/base/yz_consume.ash
+++ b/scripts/yaaz/util/base/yz_consume.ash
@@ -282,7 +282,7 @@ boolean try_drink(item it)
 
   if (have_skill($skill[the ode to booze]) && mp_cost($skill[the ode to booze]) < my_mp())
   {
-    if (have_effect($effect[ode to booze]) == 0)
+    if (have_effect($effect[ode to booze]) < it.inebriety)
     {
       log("Casting " + wrap($skill[the ode to booze]) + " for better booze action.");
       if (!can_cast_song()) uneffect_song();


### PR DESCRIPTION
Currently we only check if we have the effect, so if we happen to have 1 turn remaining from a previous cast, we don't try again, and run out during drinking. (Causing a kolmafia prompt of are you sure you want to drink without Ode)