### PR TITLE
Add kgblib to dependencies

### DIFF
--- a/scripts/yaaz/special/items/yz_kgb.ash
+++ b/scripts/yaaz/special/items/yz_kgb.ash
@@ -1,4 +1,3 @@
-import "kgblib/kgblib.ash";
 import "util/base/yz_print.ash";
 
 boolean can_kgb() {


### PR DESCRIPTION
YAAZ chokes and dies without this, and it's not currently in dependencies.txt.