### PR TITLE
Check current equipment of Tot before deciding item or meat familair

### DIFF
--- a/scripts/yaaz/util/base/yz_familiars.ash
+++ b/scripts/yaaz/util/base/yz_familiars.ash
@@ -136,7 +136,7 @@ familiar choose_familiar(string fam)
         newbie = $familiar[robortender];
         break;
       }
-      if (have_familiar($familiar[trick-or-treating tot]) && have($item[li'l pirate costume]))
+      if (have_familiar($familiar[trick-or-treating tot]) && i_a($item[li'l pirate costume]) > 0)
       {
         newbie = $familiar[trick-or-treating tot];
         break;
@@ -147,7 +147,7 @@ familiar choose_familiar(string fam)
       newbie = choose_familiar_from_list($familiars[Happy Medium, Xiblaxian Holo-Companion, Oily Woim]);
       break;
     case "items":
-      if (have_familiar($familiar[trick-or-treating tot]) && have($item[li'l ninja costume]))
+      if (have_familiar($familiar[trick-or-treating tot]) && i_a($item[li'l ninja costume]) > 0)
       {
         newbie = $familiar[trick-or-treating tot];
         break;


### PR DESCRIPTION
At the moment if the Tot is not your active familiar and is currently holding the ninja costume (for example) she will no longer be chosen for +item.

This fixes that.